### PR TITLE
Add Environment Variables for Database

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # current is running local database,
 spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
-spring.datasource.password=${4a5cbd894e416a78de1d0303df68306ca325f4062430171692540569a28d4783}
+spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.hibernate.show-sql=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,9 @@
 # current is running local database,
-spring.datasource.url=jdbc:postgresql://ec2-35-168-198-9.compute-1.amazonaws.com:5432/d442hhemuqnajt?sslmode=require
-spring.datasource.username=yqvfnscqletmwe
-spring.datasource.password=4a5cbd894e416a78de1d0303df68306ca325f4062430171692540569a28d4783
+spring.datasource.url=${JDBC_DATABASE_URL}
+spring.datasource.username=${JDBC_DATABASE_USERNAME}
+spring.datasource.password=${4a5cbd894e416a78de1d0303df68306ca325f4062430171692540569a28d4783}
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.show-sql=true
 
 #testing on local database credentials
 #spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL
@@ -17,9 +18,6 @@ spring.jpa.hibernate.ddl-auto=update
 #spring.jpa.hibernate.ddl-auto=none
 #spring.jpa.hibernate.show-sql=true
 
-#spring.datasource.url=jdbc:postgresql://db-projects.postgres.database.azure.com:5432/studymonkey
-#spring.datasource.username=AzureUser@db-projects
-#spring.datasource.password=sysc4806@123
 
 #spring.datasource.initialization-mode=always
 #spring.datasource.initialize=true


### PR DESCRIPTION
Hide credentials using environment variables. The environment variables were also configured in Travis CI and Heroku.

Once this PR has been merged, we may want to git reset the commits that had the database credentials.